### PR TITLE
Report the versions of dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
 
     <dropwizard.version>0.8.1</dropwizard.version>
     <junit.version>4.12</junit.version>
+    <mockito.version>1.9.5</mockito.version>
+    <reflections.version>0.9.9</reflections.version>
   </properties>
 
   <build>
@@ -86,7 +88,6 @@
               <violationSeverity>warning</violationSeverity>
               <failOnViolation>true</failOnViolation>
               <failsOnError>true</failsOnError>
-              <linkXRef>false</linkXRef>
             </configuration>
             <goals>
               <goal>check</goal>
@@ -121,11 +122,26 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Reflections -->
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>${reflections.version}</version>
+    </dependency>
+
     <!-- JUnit -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Mockito -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # dropwizard-version-bundle
 
-A [Dropwizard][dropwizard] bundle that exposes the version of your application via the admin port.
+A [Dropwizard][dropwizard] bundle that exposes the version of your application as well as its
+dependencies via the admin port.
 
 [![Build Status](https://secure.travis-ci.org/dropwizard-bundles/dropwizard-version-bundle.png?branch=master)]
 (http://travis-ci.org/dropwizard-bundles/dropwizard-version-bundle)
@@ -14,7 +15,7 @@ Just add this maven dependency to get started:
 <dependency>
   <groupId>io.dropwizard-bundles</groupId>
   <artifactId>dropwizard-version-bundle</artifactId>
-  <version>0.8.1-1</version>
+  <version>0.8.1-2</version>
 </dependency>
 ```
 
@@ -36,7 +37,7 @@ public class MyApplication extends Application<Configuration> {
 ```
 
 Now you can access the the `/version` URL on the admin port of your application to see the version
-of your application.
+of your application as well as its dependencies.
 
 For example if your application were running on `localhost` with the admin server on port 8081 then
 something like the following would show you your application's version.

--- a/src/main/java/io/dropwizard/bundles/version/VersionBundle.java
+++ b/src/main/java/io/dropwizard/bundles/version/VersionBundle.java
@@ -50,7 +50,7 @@ public class VersionBundle implements Bundle {
 
   @Override
   public void run(Environment environment) {
-    VersionServlet servlet = new VersionServlet(supplier);
+    VersionServlet servlet = new VersionServlet(supplier, environment.getObjectMapper());
     environment.admin().addServlet("version", servlet).addMapping(url);
   }
 }

--- a/src/main/java/io/dropwizard/bundles/version/VersionBundle.java
+++ b/src/main/java/io/dropwizard/bundles/version/VersionBundle.java
@@ -1,7 +1,5 @@
 package io.dropwizard.bundles.version;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import io.dropwizard.Bundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -17,7 +15,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class VersionBundle implements Bundle {
   private static final String DEFAULT_URL = "/version";
 
-  private final Supplier<String> supplier;
+  private final VersionSupplier supplier;
   private final String url;
 
   /**
@@ -41,7 +39,7 @@ public class VersionBundle implements Bundle {
     checkNotNull(supplier);
     checkNotNull(url);
 
-    this.supplier = Suppliers.memoize(supplier);
+    this.supplier = supplier;
     this.url = url;
   }
 

--- a/src/main/java/io/dropwizard/bundles/version/VersionServlet.java
+++ b/src/main/java/io/dropwizard/bundles/version/VersionServlet.java
@@ -1,8 +1,11 @@
 package io.dropwizard.bundles.version;
 
-import com.google.common.base.Supplier;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
+import io.dropwizard.jackson.Jackson;
 import java.io.IOException;
+import java.util.Map;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -10,27 +13,62 @@ import javax.servlet.http.HttpServletResponse;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * A simple servlet that will return the application version along with the versions of its
+ * dependencies as a JSON object.  For example:
+ * <pre>
+ *   {
+ *     application: "1.0.0-SNAPSHOT",
+ *     dependencies: {
+ *       "com.google.guava:guava": "18.0",
+ *       "io.dropwizard:dropwizard-core": "0.8.1"
+ *     }
+ *   }
+ * </pre>
+ *
+ * <p><b>NOTE:</b> This class intentionally delays asking the provided {@code VersionSupplier} for
+ * versions until the servlet is called.  Because of this, the supplier will be invoked for each
+ * request to the servlet.  The provided implementation of {@code VersionSupplier} should memoize
+ * its results so that a recalculation doesn't happen on every request.</p>
+ */
 class VersionServlet extends HttpServlet {
-  private final Supplier<String> supplier;
+  private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper();
 
-  VersionServlet(Supplier<String> supplier) {
+  private final VersionSupplier supplier;
+
+  VersionServlet(VersionSupplier supplier) {
     this.supplier = checkNotNull(supplier);
   }
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    String version = supplier.get();
-    if (version == null) {
-      resp.sendError(500, "Unable to determine version.");
+    String applicationVersion;
+    try {
+      applicationVersion = supplier.getApplicationVersion();
+    } catch (Throwable t) {
+      resp.sendError(500, "Unable to determine application version.");
       return;
     }
 
+    Map<String, String> dependencyVersions;
+    try {
+      dependencyVersions = supplier.getDependencyVersions();
+    } catch (Throwable t) {
+      resp.sendError(500, "Unable to determine dependency versions.");
+      return;
+    }
+
+    Map<String, Object> response = Maps.newHashMap();
+    response.put("application", applicationVersion);
+    response.put("dependencies", dependencyVersions);
+
+    // At this point we've collected all of the data we need, we know the result will be a success.
     resp.setStatus(200);
-    resp.setContentType("text/plain");
+    resp.setContentType("application/json");
 
     ServletOutputStream out = resp.getOutputStream();
     try {
-      out.print(version);
+      OBJECT_MAPPER.writeValue(out, response);
     } finally {
       Closeables.close(out, false);
     }

--- a/src/main/java/io/dropwizard/bundles/version/VersionServlet.java
+++ b/src/main/java/io/dropwizard/bundles/version/VersionServlet.java
@@ -32,12 +32,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * its results so that a recalculation doesn't happen on every request.</p>
  */
 class VersionServlet extends HttpServlet {
-  private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper();
-
   private final VersionSupplier supplier;
+  private final ObjectMapper objectMapper;
 
-  VersionServlet(VersionSupplier supplier) {
+  VersionServlet(VersionSupplier supplier, ObjectMapper objectMapper) {
     this.supplier = checkNotNull(supplier);
+    this.objectMapper = checkNotNull(objectMapper);
   }
 
   @Override
@@ -68,7 +68,7 @@ class VersionServlet extends HttpServlet {
 
     ServletOutputStream out = resp.getOutputStream();
     try {
-      OBJECT_MAPPER.writeValue(out, response);
+      objectMapper.writeValue(out, response);
     } finally {
       Closeables.close(out, false);
     }

--- a/src/main/java/io/dropwizard/bundles/version/VersionSupplier.java
+++ b/src/main/java/io/dropwizard/bundles/version/VersionSupplier.java
@@ -1,9 +1,18 @@
 package io.dropwizard.bundles.version;
 
-import com.google.common.base.Supplier;
+import java.util.Map;
 
 /**
  * Supplier interface that provides an application's version number.
  */
-public interface VersionSupplier extends Supplier<String> {
+public interface VersionSupplier {
+  /**
+   * Return the application's version number.
+   */
+  String getApplicationVersion();
+
+  /**
+   * Return the version numbers of dependencies.
+   */
+  Map<String, String> getDependencyVersions();
 }

--- a/src/main/java/io/dropwizard/bundles/version/suppliers/MavenVersionSupplier.java
+++ b/src/main/java/io/dropwizard/bundles/version/suppliers/MavenVersionSupplier.java
@@ -1,13 +1,22 @@
 package io.dropwizard.bundles.version.suppliers;
 
+import com.google.common.collect.Maps;
 import com.google.common.io.ByteSource;
-import com.google.common.io.Closeables;
 import com.google.common.io.Resources;
 import io.dropwizard.bundles.version.VersionSupplier;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.regex.Pattern;
+import org.reflections.Configuration;
+import org.reflections.Reflections;
+import org.reflections.scanners.ResourcesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,36 +28,59 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class MavenVersionSupplier implements VersionSupplier {
   private static final Logger LOG = LoggerFactory.getLogger(MavenVersionSupplier.class);
+  private static final Pattern POM_PROPERTIES = Pattern.compile("pom\\.properties");
 
-  private final String group;
-  private final String artifact;
-  private final String path;
+  private final String version;
+  private final SortedMap<String, String> dependencyVersions = Maps.newTreeMap();
 
   /**
-   * Construct a MavenVersionSupplier that uses the specified group and artifact as the artifact
-   * whose version to report.
+   * Construct a MavenVersionSupplier that uses the specified group and artifact as the main
+   * artifact whose version to report.
    *
-   * @param group    The maven group of the main artifact.
-   * @param artifact The maven artifact id of the main artifact.
+   * @param mainArtifactGroupId The maven group of the main artifact.
+   * @param mainArtifactId      The maven artifact id of the main artifact.
    */
-  public MavenVersionSupplier(String group, String artifact) {
-    this.group = checkNotNull(group);
-    this.artifact = checkNotNull(artifact);
-    this.path = String.format("META-INF/maven/%s/%s/pom.properties", group, artifact);
+  public MavenVersionSupplier(String mainArtifactGroupId, String mainArtifactId) {
+    Configuration config = new ConfigurationBuilder()
+        .setUrls(ClasspathHelper.forJavaClassPath())
+        .addScanners(new ResourcesScanner());
+
+    Set<String> paths = new Reflections(config).getResources(POM_PROPERTIES);
+    for (String path : paths) {
+      MavenArtifact artifact = load(path);
+
+      // Use maven style keys for artifacts "<groupId>:<artifactId>".
+      String key = String.format("%s:%s", artifact.getGroupId(), artifact.getArtifactId());
+      dependencyVersions.put(key, artifact.getVersion());
+    }
+
+    String key = String.format("%s:%s", mainArtifactGroupId, mainArtifactId);
+    version = dependencyVersions.get(key);
+  }
+
+  @Override
+  public String getApplicationVersion() {
+    return version;
+  }
+
+  @Override
+  public Map<String, String> getDependencyVersions() {
+    return dependencyVersions;
   }
 
   /**
-   * Read the artifact's version from the pom.properties file in the classpath.
+   * Load a given pom.properties file and convert its contents into a {@code MavenArtifact}
+   * instance.  If the path is not loadable or for some reason isn't structured like a standard
+   * maven pom.properties file, then {@code null} is returned instead.
    */
-  @Override
-  public String get() {
+  private static MavenArtifact load(String path) {
+    URL url = Resources.getResource(path);
+
     ByteSource source;
     try {
-      URL url = Resources.getResource(path);
       source = Resources.asByteSource(url);
     } catch (IllegalArgumentException e) {
-      LOG.warn("Unable to find maven pom.properties file: group:{}, artifact:{}, path:{}",
-               group, artifact, path, e);
+      LOG.warn("Unable to find maven pom.properties file: path:{}", path, e);
       return null;
     }
 
@@ -56,29 +88,52 @@ public class MavenVersionSupplier implements VersionSupplier {
     try {
       in = source.openBufferedStream();
     } catch (IOException e) {
-      LOG.error("Unable to open maven pom.properties file: group:{}, artifact:{}, path:{}",
-                group, artifact, path, e);
+      LOG.warn("Unable to open maven pom.properties file: path:{}", path, e);
       return null;
     }
 
-    String version;
+    Properties props = new Properties();
     try {
-      Properties props = new Properties();
-      try {
-        props.load(in);
-      } catch (IOException e) {
-        LOG.error("Error while loading maven pom.properties file: group:{}, artifact:{}, path:{}",
-                  group, artifact, path, e);
-        return null;
-      }
-
-      version = props.getProperty("version");
-      LOG.debug("Loaded the version for maven artifact: group:{}, artifact:{}, path:{}, version:{}",
-                group, artifact, path, version);
-    } finally {
-      Closeables.closeQuietly(in);
+      props.load(in);
+    } catch (IOException e) {
+      LOG.warn("Error while loading maven pom.properties file: path:{}", path, e);
+      return null;
     }
 
-    return version;
+    String groupId = props.getProperty("groupId");
+    String artifactId = props.getProperty("artifactId");
+    String version = props.getProperty("version");
+
+    if (groupId == null || artifactId == null || version == null) {
+      LOG.warn("Property missing in pom.properties file: path:{}, group:{}, artifact:{}, "
+               + "version:{}", groupId, artifactId, version);
+      return null;
+    }
+
+    return new MavenArtifact(groupId, artifactId, version);
+  }
+
+  private static final class MavenArtifact {
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    MavenArtifact(String groupId, String artifactId, String version) {
+      this.groupId = checkNotNull(groupId);
+      this.artifactId = checkNotNull(artifactId);
+      this.version = checkNotNull(version);
+    }
+
+    public String getGroupId() {
+      return groupId;
+    }
+
+    public String getArtifactId() {
+      return artifactId;
+    }
+
+    public String getVersion() {
+      return version;
+    }
   }
 }

--- a/src/test/java/io/dropwizard/bundles/version/VersionServletTest.java
+++ b/src/test/java/io/dropwizard/bundles/version/VersionServletTest.java
@@ -1,7 +1,13 @@
 package io.dropwizard.bundles.version;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+import io.dropwizard.jackson.Jackson;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Map;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlet.ServletTester;
@@ -10,12 +16,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class VersionServletTest {
+  private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper();
   private static final String PATH = "/version";
 
   private final ServletTester tester = new ServletTester();
-  private final SettableVersionSupplier supplier = new SettableVersionSupplier();
+  private final VersionSupplier supplier = mock(VersionSupplier.class);
 
   @Before
   public void setup() throws Exception {
@@ -29,17 +39,62 @@ public class VersionServletTest {
   }
 
   @Test
-  public void testNonNullVersion() {
-    supplier.set("version");
+  public void testNonNullApplicationVersion() {
+    when(supplier.getApplicationVersion()).thenReturn("version");
 
     HttpTester.Response response = get();
     assertEquals(200, response.getStatus());
-    assertEquals("version", response.getContent());
+
+    JsonNode root = fromJson(response.getContent());
+    assertEquals("version", root.get("application").textValue());
   }
 
   @Test
-  public void testNullVersion() {
-    supplier.set(null);
+  public void testNullApplicationVersion() {
+    when(supplier.getApplicationVersion()).thenReturn(null);
+
+    HttpTester.Response response = get();
+    assertEquals(200, response.getStatus());
+
+    JsonNode root = fromJson(response.getContent());
+    assertNull(root.get("application").textValue());
+  }
+
+  @Test
+  public void testThrowsApplicationVersionException() {
+    RuntimeException exception = new RuntimeException();
+    when(supplier.getApplicationVersion()).thenThrow(exception);
+
+    HttpTester.Response response = get();
+    assertEquals(500, response.getStatus());
+  }
+
+  @Test
+  public void testNonNullDependencyVersion() {
+    when(supplier.getDependencyVersions()).thenReturn(map("guava", "version"));
+
+    HttpTester.Response response = get();
+    assertEquals(200, response.getStatus());
+
+    JsonNode root = fromJson(response.getContent());
+    assertEquals("version", root.get("dependencies").get("guava").textValue());
+  }
+
+  @Test
+  public void testNullDependencyVersion() {
+    when(supplier.getDependencyVersions()).thenReturn(map("guava", null));
+
+    HttpTester.Response response = get();
+    assertEquals(200, response.getStatus());
+
+    JsonNode root = fromJson(response.getContent());
+    assertNull(root.get("dependencies").get("guava").textValue());
+  }
+
+  @Test
+  public void testThrowsDependencyVersionException() {
+    RuntimeException exception = new RuntimeException();
+    when(supplier.getDependencyVersions()).thenThrow(exception);
 
     HttpTester.Response response = get();
     assertEquals(500, response.getStatus());
@@ -63,16 +118,17 @@ public class VersionServletTest {
     return response;
   }
 
-  private static final class SettableVersionSupplier implements VersionSupplier {
-    private String version;
-
-    public void set(String version) {
-      this.version = version;
+  private static JsonNode fromJson(String s) {
+    try {
+      return OBJECT_MAPPER.readTree(s);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
     }
+  }
 
-    @Override
-    public String get() {
-      return version;
-    }
+  private static Map<String, String> map(String key, String value) {
+    Map<String, String> m = Maps.newHashMap();
+    m.put(key, value);
+    return m;
   }
 }

--- a/src/test/java/io/dropwizard/bundles/version/VersionServletTest.java
+++ b/src/test/java/io/dropwizard/bundles/version/VersionServletTest.java
@@ -29,7 +29,7 @@ public class VersionServletTest {
 
   @Before
   public void setup() throws Exception {
-    tester.addServlet(new ServletHolder(new VersionServlet(supplier)), PATH);
+    tester.addServlet(new ServletHolder(new VersionServlet(supplier, OBJECT_MAPPER)), PATH);
     tester.start();
   }
 


### PR DESCRIPTION
This change updates the VersionServlet to no longer just report the version of the
main application artifact but also of all dependencies found in the classpath.
Dependencies are discovered by scanning the classpath and looking for
`pom.properties` files in `META-INF/maven` subdirectories.  These `pom.properties`
files are put into jars when Maven builds packages and includes the version of the
dependency making it ideal for this use case.
