### PR TITLE
Upgrade from Dropwizard 1.0.0 to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.dropwizard-bundles</groupId>
   <artifactId>dropwizard-version-bundle</artifactId>
-  <version>1.0.1-SNAPSHOT</version>  <!-- Make sure to keep this in sync with the dropwizard version below. -->
+  <version>1.0.2-SNAPSHOT</version>  <!-- Make sure to keep this in sync with the dropwizard version below. -->
   <packaging>jar</packaging>
 
   <name>dropwizard-version-bundle</name>
@@ -48,7 +48,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <dropwizard.version>1.0.0</dropwizard.version>
+    <dropwizard.version>1.0.2</dropwizard.version>
     <junit.version>4.12</junit.version>
     <mockito.version>1.10.17</mockito.version>
     <reflections.version>0.9.10</reflections.version>


### PR DESCRIPTION
[Dropwizard 1.0.1](http://www.dropwizard.io/1.0.2/docs/about/release-notes.html#v1-0-1-sep-21-2016) was released on 23 September and [1.0.2](http://www.dropwizard.io/1.0.2/docs/about/release-notes.html#v1-0-2-sep-23-2016) two days later. Maybe you want a 1.0.1 release for the sake of completeness.
