### PR TITLE
Provide optional access to Configuration when constructing a VersionSupplier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,18 @@
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.dropwizard-bundles</groupId>
-    <artifactId>parent-pom</artifactId>
-    <version>1.3.5</version>
-  </parent>
-
+  <groupId>io.dropwizard-bundles</groupId>
   <artifactId>dropwizard-version-bundle</artifactId>
-  <version>1.3.5-1-SNAPSHOT</version>  <!-- Make sure to keep this in sync with the parent pom version above. -->
+  <version>4.0.0</version>
   <packaging>jar</packaging>
 
   <name>dropwizard-version-bundle</name>
@@ -22,13 +17,6 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-
-  <scm>
-    <url>http://github.com/dropwizard-bundles/dropwizard-version-bundle</url>
-    <connection>scm:git:https://github.com/dropwizard-bundles/dropwizard-version-bundle</connection>
-    <developerConnection>scm:git:https://github.com/dropwizard-bundles/dropwizard-version-bundle</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
 
   <developers>
     <developer>
@@ -45,49 +33,35 @@
 
   <properties>
     <reflections.version>0.9.11</reflections.version>
+    <dw.version>4.0.2</dw.version>
   </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <release>16</release>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-core</artifactId>
+      <version>${dw.version}</version>
+      <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>io.dropwizard</groupId>
-      <artifactId>dropwizard-testing</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>${reflections.version}</version>
+      <version>0.9.11</version> <!-- Warning: Do not upgrade the library otherwise the extension will stop working -->
 
       <!--
         Don't include the annotations.jar, it contains the annotations defined in javax.annotation
@@ -103,5 +77,26 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-testing</artifactId>
+      <version>${dw.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.2.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <reflections.version>0.9.11</reflections.version>
-    <dw.version>4.0.2</dw.version>
+    <dw.version>4.0.11</dw.version>
   </properties>
 
   <build>

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,31 @@ public class MyApplication extends Application<Configuration> {
 }
 ```
 
+
+Or if you need access to your configuration in your supplier use the `ConfiguredVersionBundle` as follows:
+
+```java
+public class MyApplication extends Application<Configuration> {
+  @Override
+  public void initialize(Bootstrap<Configuration> bootstrap) {
+    bootstrap.addBundle(new ConfiguredVersionBundle<Configuration>()
+    {
+        @Override
+        public VersionSupplier provideSupplier(Configuration configuration)
+        {
+            return new MyConfiguredVersionSupplier(configuration);
+        }
+    });
+  }
+
+  @Override
+  public void run(Configuration cfg, Environment env) throws Exception {
+    // ...
+  }
+}
+```
+
+
 Now you can access the the `/version` URL on the admin port of your application to see the version
 of your application as well as its dependencies.
 

--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,6 @@
 A [Dropwizard][dropwizard] bundle that exposes the version of your application as well as its
 dependencies via the admin port.
 
-[![Build Status](https://secure.travis-ci.org/dropwizard-bundles/dropwizard-version-bundle.png?branch=master)]
-(http://travis-ci.org/dropwizard-bundles/dropwizard-version-bundle)
-
-
 ## Getting Started
 
 Just add this maven dependency to get started:
@@ -15,7 +11,7 @@ Just add this maven dependency to get started:
 <dependency>
   <groupId>io.dropwizard-bundles</groupId>
   <artifactId>dropwizard-version-bundle</artifactId>
-  <version>1.0.5</version>
+  <version>1.3.5</version>
 </dependency>
 ```
 

--- a/src/main/java/io/dropwizard/bundles/version/ConfiguredVersionBundle.java
+++ b/src/main/java/io/dropwizard/bundles/version/ConfiguredVersionBundle.java
@@ -1,0 +1,55 @@
+package io.dropwizard.bundles.version;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A Dropwizard bundle that will expose a version number of the application via a servlet on the
+ * admin console port.  The way that the bundle discovers the application's version number is
+ * configurable via a {@code VersionSupplier}.  The provided {@code VersionSupplier} implementation
+ * will be called a single time and the value it returns will be memoized for the life of the JVM.
+ */
+public abstract class ConfiguredVersionBundle<T extends Configuration>
+        implements ConfiguredBundle<T> {
+  private static final String DEFAULT_URL = "/version";
+
+  private final String url;
+
+  /**
+   * Construct the VersionBundle.  The version number
+   * will be exposed on the Dropwizard admin port on the default URL.
+   */
+  public ConfiguredVersionBundle() {
+    this(DEFAULT_URL);
+  }
+
+  /**
+   * Construct a VersionBundle.  The version number will
+   * be exposed on the Dropwizard admin port at the specified URL.
+   *
+   * @param url The URL to expose the version number on.
+   */
+  public ConfiguredVersionBundle(String url) {
+    checkNotNull(url);
+
+    this.url = url;
+  }
+
+  public abstract VersionSupplier provideSupplier(T configuration);
+
+  @Override
+  public void initialize(Bootstrap<?> bootstrap) {
+    // Nothing to do here
+  }
+
+  @Override
+  public void run(T configuration, Environment environment) {
+    VersionServlet servlet = new VersionServlet(provideSupplier(configuration),
+            environment.getObjectMapper());
+    environment.admin().addServlet("version", servlet).addMapping(url);
+  }
+}

--- a/src/main/java/io/dropwizard/bundles/version/ConfiguredVersionBundle.java
+++ b/src/main/java/io/dropwizard/bundles/version/ConfiguredVersionBundle.java
@@ -1,9 +1,10 @@
 package io.dropwizard.bundles.version;
 
-import io.dropwizard.Configuration;
-import io.dropwizard.ConfiguredBundle;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.ConfiguredBundle;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -14,7 +15,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * will be called a single time and the value it returns will be memoized for the life of the JVM.
  */
 public abstract class ConfiguredVersionBundle<T extends Configuration>
-        implements ConfiguredBundle<T> {
+        implements ConfiguredBundle<T>
+{
   private static final String DEFAULT_URL = "/version";
 
   private final String url;

--- a/src/main/java/io/dropwizard/bundles/version/VersionBundle.java
+++ b/src/main/java/io/dropwizard/bundles/version/VersionBundle.java
@@ -1,8 +1,10 @@
 package io.dropwizard.bundles.version;
 
-import io.dropwizard.Bundle;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.ConfiguredBundle;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -12,7 +14,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * configurable via a {@code VersionSupplier}.  The provided {@code VersionSupplier} implementation
  * will be called a single time and the value it returns will be memoized for the life of the JVM.
  */
-public class VersionBundle implements Bundle {
+public class VersionBundle<T> implements ConfiguredBundle<T> {
   private static final String DEFAULT_URL = "/version";
 
   private final VersionSupplier supplier;
@@ -49,7 +51,7 @@ public class VersionBundle implements Bundle {
   }
 
   @Override
-  public void run(Environment environment) {
+  public void run(T configuration, Environment environment) {
     VersionServlet servlet = new VersionServlet(supplier, environment.getObjectMapper());
     environment.admin().addServlet("version", servlet).addMapping(url);
   }

--- a/src/main/java/io/dropwizard/bundles/version/VersionServlet.java
+++ b/src/main/java/io/dropwizard/bundles/version/VersionServlet.java
@@ -3,13 +3,13 @@ package io.dropwizard.bundles.version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
-import io.dropwizard.jackson.Jackson;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.Map;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 


### PR DESCRIPTION
I needed to access the Configuration in my VersionSupplier (the build bakes it into the config) so I made a new type of Bundle.
Figured I'd add it back in case anyone else could use it.